### PR TITLE
TgWebValid is connected

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
   environment:
-    php: 7.3  # or any other released version
+    php: 8.0  # or any other released version
 
 filter:
   excluded_paths: [tests/*]

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
     php: 8.0  # or any other released version
 
 filter:
-  excluded_paths: [tests/*]
+  excluded_paths: [tests/*, vendor/*]
 
 checks:
   php:

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,12 @@
     ],
     "homepage": "https://github.com/pschocke/telegramloginwidget",
     "keywords": ["Laravel", "TelegramLoginWidget"],
+    "scripts": {
+        "test": "phpunit --color=always"
+    },
     "require": {
-        "illuminate/support": "~9"
+        "illuminate/support": "~9",
+        "tg/tgwebvalid": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
Hello

In this pull request, a soft connection of the [TgWebValid](https://github.com/CrazyTapok-bit/tgWebValid) package is made. This means that at this stage 100% of the backward compatibility of the project is preserved. That is, it can be used exactly as before.

This was done in order to lay the foundation for the future improvement of this project and expansion of its functionality. Namely, add the ability to check [Telegram WebApp](https://core.telegram.org/bots/webapps) users. And it will be done quite simply, because the entire implementation of the check is already in the connected library.

In addition, this library has all the necessary tests to guarantee its stability and correct operation.

Also note that I added a section of scripts in the composer.json file. This was done for the convenience of running tests, now it is easy to do with the `composer test` command

I hope you will accept my contribution to your project and allow you to make it even better in the future