### PR TITLE
Update to Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.4, 8.5]
-        laravel: [12.*]
+        laravel: [13.*]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - L ${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 .phpunit.result.cache
+.phpunit.cache/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "keywords": ["Laravel", "TelegramLoginWidget"],
     "require": {
         "php": "^8.4",
-        "illuminate/support": "^12.0"
+        "illuminate/support": "^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.0",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^11.0",
         "sempro/phpunit-pretty-print": "^1.0",
         "larastan/larastan": "^3.9"
     },


### PR DESCRIPTION
Updates the Composer package to be compatible with the newly released Laravel 13, as requested. It also updates the GitHub Actions CI workflow and updates the `.gitignore` to ignore the `.phpunit.cache/` directory created by newer PHPUnit versions. Backward compatibility is dropped as requested.

---
*PR created automatically by Jules for task [14332939107884306783](https://jules.google.com/task/14332939107884306783) started by @pschocke*